### PR TITLE
Hide client secret when logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -57,7 +57,7 @@ func LoggerWithWriter(out io.Writer) gin.HandlerFunc {
 
 		if len(formValues) > 0 {
 			for k, _ := range formValues {
-				if k == "password" {
+				if k == "password"  || k == "client_secret" {
 					formValues[k] = []string{"***"}
 				}
 			}


### PR DESCRIPTION
Update logger to also hide `client_secret` in the same way that `password` is already hidden. 

Results in the following output...
`Params: map[locale:[xxx] client_id:[xxx] password:[***] client_secret:[***]] `