### PR TITLE
Hardcode more items to hide when logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -57,7 +57,8 @@ func LoggerWithWriter(out io.Writer) gin.HandlerFunc {
 
 		if len(formValues) > 0 {
 			for k, _ := range formValues {
-				if k == "password" {
+				switch k {
+				case "password", "client_secret", "access_token", "code", "code_challenge", "state", "code_verifier":
 					formValues[k] = []string{"***"}
 				}
 			}


### PR DESCRIPTION
**This is a backup option for [this request](https://github.com/qor/log/pull/3), please close if the other is merged successfully**

Backup approach to adding new headers to hide when logging requests.

- Added (hardcoded) 5 new headers to log as `***` to protect sensitive information: `access_token`, `code`, `code_challenge`, `state`, `code_verifier`